### PR TITLE
isort, doc8, and better RTD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bake help pip-compile quality replay requirements test validate watch
+.PHONY: bake help quality replay requirements test upgrade validate watch
 
 BAKE_OPTIONS=--no-input
 
@@ -9,12 +9,12 @@ help: ## display this help message
 bake: ## generate project using defaults
 	cookiecutter $(BAKE_OPTIONS) . --overwrite-if-exists
 
-pip-compile: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
-	pip-compile -o requirements/base.txt requirements/base.in
-	pip-compile -o requirements/dev.txt requirements/dev.in
-	pip-compile -o requirements/doc.txt requirements/doc.in
-	pip-compile -o requirements/test.txt requirements/test.in
-	pip-compile -o requirements/travis.txt requirements/travis.in
+upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
+	pip-compile --upgrade -o requirements/base.txt requirements/base.in
+	pip-compile --upgrade -o requirements/dev.txt requirements/dev.in
+	pip-compile --upgrade -o requirements/doc.txt requirements/doc.in
+	pip-compile --upgrade -o requirements/test.txt requirements/test.in
+	pip-compile --upgrade -o requirements/travis.txt requirements/travis.in
 
 quality: ## check coding style with pycodestyle and pylint
 	tox -e quality

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ Generate a virtualenv and generate requirements files with dependencies
 pinned to current versions (make sure you're using pip 7 or later)::
 
     $ mkvirtualenv Blogging-for-humans
-    $ make pip-compile
+    $ make upgrade
 
 Create a GitHub repo and push it there::
 
@@ -117,10 +117,10 @@ Code has been written, but does it actually work? Let's find out!
 Register on PyPI
 ~~~~~~~~~~~~~~~~~
 
-Once you've got at least a prototype working and tests running, it's time to register the app on PyPI::
+Once you've got at least a prototype working and tests running, it's time to
+`register the application on PyPI`_.
 
-    python setup.py register
-
+.. _register the application on PyPI: https://packaging.python.org/distributing/#register-your-project
 
 Releasing on PyPI
 ~~~~~~~~~~~~~~~~~

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -2,10 +2,10 @@
 
 from __future__ import absolute_import, unicode_literals
 
+import logging
 import re
 import sys
 
-import logging
 logging.basicConfig(level=logging.DEBUG)
 
 logger = logging.getLogger('pre_gen_project')  # pylint: disable=C0103

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,7 @@ MarkupSafe==0.23          # via jinja2
 pathtools==0.1.2          # via watchdog
 poyo==0.4.0               # via cookiecutter
 python-dateutil==2.5.3    # via arrow
-PyYAML==3.11              # via watchdog
+PyYAML==3.12              # via watchdog
 six==1.10.0               # via python-dateutil
 watchdog==0.8.3
 whichcraft==0.4.0         # via cookiecutter

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file requirements/dev.txt requirements/dev.in
 #
-astroid==1.4.7            # via pylint, pylint-celery, pylint-plugin-utils
+astroid==1.4.8            # via pylint, pylint-celery, pylint-plugin-utils
 click==6.6                # via pip-tools
 colorama==0.3.7           # via pylint
 edx-lint==0.5.1
@@ -15,10 +15,10 @@ pluggy==0.3.1             # via tox
 py==1.4.31                # via tox
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.2.3  # via pylint-celery, pylint-django
+pylint-plugin-utils==0.2.4  # via pylint-celery, pylint-django
 pylint==1.5.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 six==1.10.0               # via astroid, edx-lint, pip-tools, pylint
-tox-battery==0.0.1
+tox-battery==0.2
 tox==2.3.1
-virtualenv==15.0.2        # via tox
+virtualenv==15.0.3        # via tox
 wrapt==1.10.8             # via astroid

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -4,6 +4,7 @@ caniusepython3            # Additional Python 3 compatibility pylint checks
 Django                    # For pylint import checks of the generated output
 django-model-utils        # For pylint import checks of the generated output
 edx-lint                  # edX pylint rules and plugins
+isort                     # to standardize order of imports
 pycodestyle               # PEP 8 compliance validation
 pydocstyle                # PEP 257 compliance validation
 pytest-catchlog           # Show log output for test failures

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,27 +4,28 @@
 #
 #    pip-compile --output-file requirements/test.txt requirements/test.in
 #
-alabaster==0.7.8          # via sphinx
+alabaster==0.7.9          # via sphinx
 argparse==1.4.0           # via caniusepython3
 arrow==0.8.0              # via jinja2-time
-astroid==1.4.7            # via pylint, pylint-celery, pylint-plugin-utils
+astroid==1.4.8            # via pylint, pylint-celery, pylint-plugin-utils
 babel==2.3.4              # via sphinx
 binaryornot==0.4.0        # via cookiecutter
 bleach==1.4.3             # via readme-renderer
-caniusepython3==3.4.0
+caniusepython3==4.0.0
 chardet==2.3.0            # via binaryornot
 click==6.6                # via cookiecutter
 colorama==0.3.7           # via pylint
 cookiecutter==1.4.0       # via pytest-cookies
 distlib==0.2.3            # via caniusepython3
-django-model-utils==2.5
-Django==1.9.8             # via django-model-utils
+django-model-utils==2.6
+Django==1.10.1            # via django-model-utils
 docutils==0.12            # via readme-renderer, sphinx
 edx-lint==0.5.1
 future==0.15.2            # via cookiecutter
 futures==3.0.5            # via caniusepython3
 html5lib==0.9999999       # via bleach
 imagesize==0.7.1          # via sphinx
+isort==4.2.5
 jinja2-time==0.2.0        # via cookiecutter
 jinja2==2.8               # via cookiecutter, jinja2-time, sphinx
 lazy-object-proxy==1.2.2  # via astroid
@@ -37,20 +38,21 @@ pydocstyle==1.0.0
 Pygments==2.1.3           # via readme-renderer, sphinx
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.2.3  # via pylint-celery, pylint-django
+pylint-plugin-utils==0.2.4  # via pylint-celery, pylint-django
 pylint==1.5.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pyparsing==2.1.5          # via packaging
+pyparsing==2.1.9          # via packaging
 pytest-catchlog==1.2.2
 pytest-cookies==0.2.0
-pytest==2.9.2             # via pytest-catchlog, pytest-cookies
+pytest==3.0.2             # via pytest-catchlog, pytest-cookies
 python-dateutil==2.5.3    # via arrow
 pytz==2016.6.1            # via babel
 readme-renderer==0.7.0
+requests==2.11.1          # via caniusepython3
 sh==1.11
 six==1.10.0               # via astroid, bleach, edx-lint, html5lib, packaging, pylint, python-dateutil, readme-renderer, sphinx
 snowballstemmer==1.2.1    # via sphinx
 sphinx-rtd-theme==0.1.9
-sphinx==1.4.5             # via sphinx-rtd-theme
+sphinx==1.4.6             # via sphinx-rtd-theme
 whichcraft==0.4.0         # via cookiecutter
 wrapt==1.10.8             # via astroid
 

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -6,6 +6,6 @@
 #
 pluggy==0.3.1             # via tox
 py==1.4.31                # via tox
-tox-battery==0.0.1
+tox-battery==0.2
 tox==2.3.1
-virtualenv==15.0.2        # via tox
+virtualenv==15.0.3        # via tox

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -4,15 +4,15 @@ Tests of the project generation output.
 
 from __future__ import absolute_import, print_function, unicode_literals
 
-from contextlib import contextmanager
 import logging
 import logging.config
 import os
 import re
+from contextlib import contextmanager
 
-from cookiecutter.utils import rmtree
-import sh
 import pytest
+import sh
+from cookiecutter.utils import rmtree
 
 LOGGING_CONFIG = {
     'version': 1,

--- a/tox.ini
+++ b/tox.ini
@@ -30,3 +30,4 @@ commands =
     pylint --py3k tests/test_bake_project.py
     pycodestyle tests/test_bake_project.py
     pydocstyle tests/test_bake_project.py
+    isort --check-only --recursive hooks tests

--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -68,3 +68,6 @@ requirements/private.txt
 
 # tox environment temporary artifacts
 tests/__init__.py
+
+# Development task artifacts
+default.db

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -38,4 +38,4 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
-    condition: '$TOXENV = py35-django19'
+    condition: '$TOXENV = quality'

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -1,5 +1,5 @@
 .PHONY: clean compile_translations coverage docs dummy_translations extract_translations \
-	fake_translations help pull_translations push_translations quality requirements test test-all validate
+	fake_translations help pull_translations push_translations quality requirements test test-all upgrade validate
 
 .DEFAULT_GOAL := help
 
@@ -48,11 +48,11 @@ extract_translations: ## extract strings to be translated, outputting .mo files
 
 fake_translations: extract_translations dummy_translations compile_translations ## generate and compile dummy translation files
 
-pip-compile: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
+upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -q pip-tools
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in
-	pip-compile --upgrade -o requirements/dev.txt requirements/dev.in
-	pip-compile --upgrade -o requirements/doc.txt requirements/doc.in
+	pip-compile --upgrade -o requirements/dev.txt requirements/dev.in requirements/quality.in
+	pip-compile --upgrade -o requirements/doc.txt requirements/base.in requirements/doc.in
 	pip-compile --upgrade -o requirements/quality.txt requirements/quality.in
 	pip-compile --upgrade -o requirements/test.txt requirements/base.in requirements/test.in
 	pip-compile --upgrade -o requirements/travis.txt requirements/travis.in

--- a/{{cookiecutter.repo_name}}/requirements/dev.in
+++ b/{{cookiecutter.repo_name}}/requirements/dev.in
@@ -1,7 +1,7 @@
 # Additional requirements for development of this application
 
 edx-lint                  # For updating pylintrc
--e git+https://github.com/edx/i18n-tools.git@v0.3.2#egg=i18n_tools==0.3.2  # For i18n_tool dummy
+edx-i18n-tools            # For i18n_tool dummy
 pip-tools                 # Requirements file management
 tox                       # virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/{{cookiecutter.repo_name}}/requirements/doc.in
+++ b/{{cookiecutter.repo_name}}/requirements/doc.in
@@ -1,5 +1,6 @@
 # Requirements for documentation validation
 
+doc8                      # reStructuredText style checker
 readme_renderer           # Validates README.rst for usage on PyPI
 Sphinx                    # Documentation builder
 sphinx_rtd_theme          # ReadTheDocs theme for Sphinx output

--- a/{{cookiecutter.repo_name}}/requirements/quality.in
+++ b/{{cookiecutter.repo_name}}/requirements/quality.in
@@ -2,5 +2,6 @@
 
 caniusepython3            # Additional Python 3 compatibility pylint checks
 edx-lint                  # edX pylint rules and plugins
+isort                     # to standardize order of imports
 pycodestyle               # PEP 8 compliance validation
 pydocstyle                # PEP 257 compliance validation

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -1,2 +1,10 @@
+[isort]
+line_length = 120
+known_edx =
+known_django = django
+known_djangoapp = model_utils
+known_first_party = {{ cookiecutter.app_name }}
+sections = FUTURE,STDLIB,THIRDPARTY,DJANGO,DJANGOAPP,EDX,FIRSTPARTY,LOCALFOLDER
+
 [wheel]
 universal = 1

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -1,6 +1,9 @@
 [tox]
 envlist = {py27,py35}-django{18,19,110}
 
+[doc8]
+max-line-length = 120
+
 [pep8]
 exclude = .git,.tox,migrations
 max-line-length = 120
@@ -31,12 +34,11 @@ whitelist_externals =
     make
     rm
 deps =
-    -r{toxinidir}/requirements/base.txt
     -r{toxinidir}/requirements/doc.txt
 commands =
+    doc8 --ignore-path docs/_build README.rst docs
     rm -f docs/{{ cookiecutter.app_name }}.rst
     rm -f docs/modules.rst
-    sphinx-apidoc -o docs/ {{ cookiecutter.app_name }}
     make -C docs clean
     make -C docs html
     python setup.py check --restructuredtext --strict
@@ -47,7 +49,7 @@ whitelist_externals =
     rm
     touch
 deps =
-    Django>=1.10,<1.11
+    -r{toxinidir}/requirements/doc.txt
     -r{toxinidir}/requirements/quality.txt
     -r{toxinidir}/requirements/test.txt
 commands =
@@ -59,4 +61,5 @@ commands =
     rm tests/__init__.py
     pycodestyle {{ cookiecutter.app_name }} tests
     pydocstyle {{ cookiecutter.app_name }} tests
+    isort --check-only --recursive tests {{ cookiecutter.app_name }} manage.py setup.py test_settings.py
     make help

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/conf/locale/config.yaml
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/conf/locale/config.yaml
@@ -16,6 +16,7 @@ locales:
     - da  # Danish
     - de_DE  # German (Germany)
     - el  # Greek
+    - en  # English
     - en_GB  # English (United Kingdom)
     # Don't pull these until we figure out why pages randomly display in these locales,
     # when the user's browser is in English and the user is not logged in.


### PR DESCRIPTION
* Now using isort to check compliance with the import order guidelines
* Now using doc8 to check style of reStructuredText files
* Run sphinx-apidoc in a custom Sphinx extension instead of a tox command, so it can be used on Read the Docs
* Renamed "pip-compile" make target to "upgrade", make it actually upgrade to new versions
* Updated some dependency versions
* Have requirements/dev.txt include quality check utilities for ease of running them individually
* Have requirements/doc.txt include base requirements (needed to avoid errors during sphinx-apidoc runs)