### PR TITLE
Second batch of improvements from enterprise app

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,13 +10,13 @@ binaryornot==0.4.0        # via cookiecutter
 chardet==2.3.0            # via binaryornot
 click==6.6                # via cookiecutter
 cookiecutter==1.4.0
-future==0.15.2            # via cookiecutter
+future==0.16.0            # via cookiecutter
 jinja2-time==0.2.0        # via cookiecutter
 jinja2==2.8               # via cookiecutter, jinja2-time
 MarkupSafe==0.23          # via jinja2
 pathtools==0.1.2          # via watchdog
 poyo==0.4.0               # via cookiecutter
-python-dateutil==2.5.3    # via arrow
+python-dateutil==2.6.0    # via arrow
 PyYAML==3.12              # via watchdog
 six==1.10.0               # via python-dateutil
 watchdog==0.8.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -19,6 +19,6 @@ pylint-plugin-utils==0.2.4  # via pylint-celery, pylint-django
 pylint==1.5.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 six==1.10.0               # via astroid, edx-lint, pip-tools, pylint
 tox-battery==0.2
-tox==2.4.1
-virtualenv==15.0.3        # via tox
+tox==2.5.0
+virtualenv==15.1.0        # via tox
 wrapt==1.10.8             # via astroid

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file requirements/doc.txt requirements/doc.in
 #
-bleach==1.4.3             # via readme-renderer
+bleach==1.5.0             # via readme-renderer
 docutils==0.12            # via readme-renderer
 html5lib==0.9999999       # via bleach
 Pygments==2.1.3           # via readme-renderer

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,7 +10,7 @@ arrow==0.8.0              # via jinja2-time
 astroid==1.4.8            # via pylint, pylint-celery, pylint-plugin-utils
 babel==2.3.4              # via sphinx
 binaryornot==0.4.0        # via cookiecutter
-bleach==1.4.3             # via readme-renderer
+bleach==1.5.0             # via readme-renderer
 caniusepython3==4.0.0
 chardet==2.3.0            # via binaryornot, doc8
 click==6.6                # via cookiecutter
@@ -18,25 +18,25 @@ colorama==0.3.7           # via pylint
 cookiecutter==1.4.0       # via pytest-cookies
 distlib==0.2.4            # via caniusepython3
 django-model-utils==2.6
-Django==1.10.2            # via django-model-utils
+Django==1.10.3            # via django-model-utils
 doc8==0.7.0
 docutils==0.12            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-lint==0.5.1
-edx-sphinx-theme==1.0.1
-future==0.15.2            # via cookiecutter
+edx-sphinx-theme==1.0.2
+future==0.16.0            # via cookiecutter
 futures==3.0.5            # via caniusepython3
 html5lib==0.9999999       # via bleach
 imagesize==0.7.1          # via sphinx
 isort==4.2.5
 jinja2-time==0.2.0        # via cookiecutter
-Jinja2==2.8               # via cookiecutter, jinja2-time, sphinx
+jinja2==2.8               # via cookiecutter, jinja2-time, sphinx
 lazy-object-proxy==1.2.2  # via astroid
 MarkupSafe==0.23          # via jinja2
-packaging==16.7           # via caniusepython3
+packaging==16.8           # via caniusepython3
 pbr==1.10.0               # via stevedore
 poyo==0.4.0               # via cookiecutter
 py==1.4.31                # via pytest, pytest-catchlog
-pycodestyle==2.0.0
+pycodestyle==2.2.0
 pydocstyle==1.1.1
 Pygments==2.1.3           # via readme-renderer, sphinx
 pylint-celery==0.3        # via edx-lint
@@ -46,17 +46,17 @@ pylint==1.5.4             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pyparsing==2.1.10         # via packaging
 pytest-catchlog==1.2.2
 pytest-cookies==0.2.0
-pytest==3.0.3             # via pytest-catchlog, pytest-cookies
-python-dateutil==2.5.3    # via arrow
+pytest==3.0.4             # via pytest-catchlog, pytest-cookies
+python-dateutil==2.6.0    # via arrow
 pytz==2016.7              # via babel
 readme-renderer==0.7.0
-requests==2.11.1          # via caniusepython3
+requests==2.12.1          # via caniusepython3
 restructuredtext-lint==0.17.2  # via doc8
 sh==1.11
 six==1.10.0               # via astroid, bleach, doc8, edx-lint, edx-sphinx-theme, html5lib, packaging, pylint, python-dateutil, readme-renderer, sphinx, stevedore
 snowballstemmer==1.2.1    # via sphinx
 sphinx-rtd-theme==0.1.9
-sphinx==1.4.8             # via edx-sphinx-theme, sphinx-rtd-theme
+Sphinx==1.4.8             # via edx-sphinx-theme, sphinx-rtd-theme
 stevedore==1.18.0         # via doc8
 whichcraft==0.4.0         # via cookiecutter
 wrapt==1.10.8             # via astroid

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,5 +7,5 @@
 pluggy==0.4.0             # via tox
 py==1.4.31                # via tox
 tox-battery==0.2
-tox==2.4.1
-virtualenv==15.0.3        # via tox
+tox==2.5.0
+virtualenv==15.1.0        # via tox

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py{27,35}
 skipsdist = true
 
-[pep8]
+[pycodestyle]
 max-line-length = 120
 
 [pydocstyle]

--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -61,6 +61,7 @@ output/*/index.html
 docs/_build
 docs/modules.rst
 docs/{{ cookiecutter.app_name }}.rst
+docs/{{ cookiecutter.app_name }}.*.rst
 
 # Private requirements
 requirements/private.in

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -43,7 +43,7 @@ dummy_translations: ## generate dummy translation (.po) files
 	cd {{cookiecutter.app_name}} && i18n_tool dummy
 
 extract_translations: ## extract strings to be translated, outputting .mo files
-    rm -rf docs/_build
+	rm -rf docs/_build
 	./manage.py makemessages -l en -v1 -d django
 	./manage.py makemessages -l en -v1 -d djangojs
 
@@ -76,6 +76,9 @@ requirements: ## install development environment requirements
 
 test: clean ## run tests in the current virtualenv
 	py.test
+
+diff_cover: test
+	diff-cover coverage.xml
 
 test-all: ## run tests on every supported Python/Django combination
 	tox -e quality

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -43,6 +43,7 @@ dummy_translations: ## generate dummy translation (.po) files
 	cd {{cookiecutter.app_name}} && i18n_tool dummy
 
 extract_translations: ## extract strings to be translated, outputting .mo files
+    rm -rf docs/_build
 	./manage.py makemessages -l en -v1 -d django
 	./manage.py makemessages -l en -v1 -d djangojs
 

--- a/{{cookiecutter.repo_name}}/PR_TEMPLATE.md
+++ b/{{cookiecutter.repo_name}}/PR_TEMPLATE.md
@@ -1,0 +1,39 @@
+**Description:** Describe in a couple of sentence what this PR adds
+
+**JIRA:** Link to JIRA ticket
+
+**Dependencies:** dependencies on other outstanding PRs, issues, etc. 
+
+**Merge deadline:** List merge deadline (if any)
+
+**Installation instructions:** List any non-trivial installation 
+instructions.
+
+**Testing instructions:**
+
+1. Open page A
+2. Do thing B
+3. Expect C to happen
+4. If D happend instead - check failed.
+
+**Reviewers:**
+- [ ] tag reviwer 
+- [ ] tag reviewer 
+
+**Merge checklist:**
+- [ ] All reviewers approved
+- [ ] CI build is green
+- [ ] Version bumped
+- [ ] Changelog record added
+- [ ] Commits are squashed
+- [ ] PR author is listed in AUTHORS
+
+**Post merge:**
+- [ ] Create a tag
+- [ ] Check new version is pushed to PyPi after tag-triggered build is 
+      finished.
+- [ ] Delete working branch (if not needed anymore)
+
+**Author concerns:** List any concerns about this PR - inelegant 
+solutions, hacks, quick-and-dirty implementations, concerns about 
+migrations, etc.

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -62,6 +62,9 @@ Please read `How To Contribute <https://github.com/edx/edx-platform/blob/master/
 Even though they were written with ``edx-platform`` in mind, the guidelines
 should be followed for Open edX code in general.
 
+PR description template can be found at
+`PR_TEMPLATE.md <https://github.com/edx/{{ cookiecutter.repo_name }}/blob/master/PR_TEMPLATE.md>`_
+
 Reporting Security Issues
 -------------------------
 

--- a/{{cookiecutter.repo_name}}/codecov.yml
+++ b/{{cookiecutter.repo_name}}/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        enabled: yes
+        target: auto
+    patch:
+      default:
+        enabled: yes
+        target: 100%
+
+comment: false

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -50,6 +50,7 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.ifconfig',
+    'sphinxcontrib.napoleon'
 ]
 
 # A list of warning types to suppress arbitrary warning messages.

--- a/{{cookiecutter.repo_name}}/docs/testing.rst
+++ b/{{cookiecutter.repo_name}}/docs/testing.rst
@@ -15,6 +15,12 @@ To run just the unit tests:
 
     $ make test
 
+To run just the unit tests and check diff coverage
+
+.. code-block:: bash
+
+    $ make diff_cover
+
 To run just the code quality checks:
 
 .. code-block:: bash

--- a/{{cookiecutter.repo_name}}/requirements/dev.in
+++ b/{{cookiecutter.repo_name}}/requirements/dev.in
@@ -1,5 +1,6 @@
 # Additional requirements for development of this application
 
+diff-cover                # Changeset diff test coverage
 edx-lint                  # For updating pylintrc
 edx-i18n-tools            # For i18n_tool dummy
 pip-tools                 # Requirements file management

--- a/{{cookiecutter.repo_name}}/requirements/doc.in
+++ b/{{cookiecutter.repo_name}}/requirements/doc.in
@@ -4,3 +4,4 @@ doc8                      # reStructuredText style checker
 edx_sphinx_theme          # edX theme for Sphinx output
 readme_renderer           # Validates README.rst for usage on PyPI
 Sphinx                    # Documentation builder
+sphinxcontrib-napoleon    # Google Style docstring support for sphinx

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -24,6 +24,7 @@ def get_version(*file_paths):
         return version_match.group(1)
     raise RuntimeError('Unable to find version string.')
 
+
 VERSION = get_version('{{ cookiecutter.app_name }}', '__init__.py')
 
 if sys.argv[-1] == 'tag':

--- a/{{cookiecutter.repo_name}}/test_settings.py
+++ b/{{cookiecutter.repo_name}}/test_settings.py
@@ -16,6 +16,7 @@ def root(*args):
     """
     return join(abspath(dirname(__file__)), *args)
 
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -18,7 +18,7 @@ match-dir = (?!migrations)
 
 [pytest]
 DJANGO_SETTINGS_MODULE = test_settings
-addopts = --cov {{ cookiecutter.app_name }} --cov-report term-missing
+addopts = --cov {{ cookiecutter.app_name }} --cov-report term-missing --cov-report xml
 norecursedirs = .* docs requirements
 
 [testenv]

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -4,7 +4,7 @@ envlist = {py27,py35}-django{18,19,110}
 [doc8]
 max-line-length = 120
 
-[pep8]
+[pycodestyle]
 exclude = .git,.tox,migrations
 max-line-length = 120
 


### PR DESCRIPTION
**Description:** This PR contains fixes and improvements found working on new edx-enterprise app.

**JIRA:** [ENT-21](https://openedx.atlassian.net/browse/ENT-48)

**Related:** https://github.com/edx/edx-enterprise/pull/8

**Testing instructions:**

Run tests and make sure they are passing.
Try generating new app (as described in this repo's README) and check the following:

- generated docs/{{appname}}.*.rst is gitignored (add a package and run `make docs`)
- `make diff_cover` runs test suite and reports diff coverage.
- `make extract_translations` after `make docs` does not generate djangojs.po with strings from `docs/_build`
- Repo contains PR template
- codecov config file is present
- Google style docstrings are properly parsed by Sphinx (i.e. `Arguments` clause is parsed into parameters, see https://github.com/edx/edx-enterprise/pull/8#discussion_r87990254)
- `make quality` does not produce pycodestyle warning about `pep8` section in tox.ini

**Reviewers:**
- [x] @mtyaka (OpenCraft internal review)
- [x] @jmbowman 