### PR TITLE
Install most recent Pip on Travis

### DIFF
--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -20,6 +20,9 @@ matrix:
 
 cache:
   - pip
+  
+before_install:
+  - pip install --upgrade pip
 
 install:
   - pip install -r requirements/travis.txt


### PR DESCRIPTION
Travis by default currently uses pip 6.0.7. Pip-tools requires pip 6.1 or greater.