### PR TITLE
Remove custom isort import groups

### DIFF
--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -4,13 +4,13 @@ Tests of the project generation output.
 
 from __future__ import absolute_import, print_function, unicode_literals
 
-import logging
 import logging.config
 import os
 import re
 from contextlib import contextmanager
 
 import pytest
+
 import sh
 from cookiecutter.utils import rmtree
 

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -20,9 +20,8 @@ import re
 import sys
 from subprocess import check_call
 
-import edx_theme
-
 import django
+import edx_theme
 from django.conf import settings
 from django.utils import six
 

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -1,10 +1,7 @@
 [isort]
+indent='    '
 line_length = 120
-known_edx =
-known_django = django
-known_djangoapp = model_utils
-known_first_party = {{ cookiecutter.app_name }}
-sections = FUTURE,STDLIB,THIRDPARTY,DJANGO,DJANGOAPP,EDX,FIRSTPARTY,LOCALFOLDER
+multi_line_output=3
 
 [wheel]
 universal = 1

--- a/{{cookiecutter.repo_name}}/tests/test_models.py
+++ b/{{cookiecutter.repo_name}}/tests/test_models.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """
 Tests for the `{{ cookiecutter.repo_name }}` models module.
+
+isort:skip_file
 """
 
 from __future__ import absolute_import, unicode_literals{% if cookiecutter.models != "Comma-separated list of models" %}{% for model in cookiecutter.models.replace(' ', '').split(',') %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/models.py
@@ -4,11 +4,14 @@ Database models for {{cookiecutter.app_name}}.
 """
 
 from __future__ import absolute_import, unicode_literals
-{% if cookiecutter.models != "Comma-separated list of models" %}
+
 # from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
 from model_utils.models import TimeStampedModel
+
+{% if cookiecutter.models != "Comma-separated list of models" %}
+
 {% for model in cookiecutter.models.replace(' ', '').split(',') %}
 
 @python_2_unicode_compatible


### PR DESCRIPTION
It seems simpler to use the default isort import groups so that all of the edX repos don't need to maintain the same hand-coded list of library names. The benefit of having additional groups seems small compared to the maintenance burden they introduce.

Note: this is currently the configuration used in edx-platform. Any changes we choose to make here should then be applied to edx-platform too. 

FYI @clintonb @doctoryes @robrap 