### PR TITLE
Update for new Python, Django, and dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.5
-      env: TOXENV=py35
-    - python: 3.5
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.6
       env: TOXENV=quality
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test: ## run tests on every supported Python version
 	tox
 
 validate: ## run tests and quality checks
-	tox -e quality,py27,py35
+	tox -e quality,py27,py36
 
 watch: bake ## generate project using defaults and watch for changes
 	watchmedo shell-command -p '*.*' -c 'make bake -e BAKE_OPTIONS=$(BAKE_OPTIONS)' -W -R -D \{{cookiecutter.repo_name}}/

--- a/README.rst
+++ b/README.rst
@@ -35,10 +35,10 @@ Usage
 
 First, create your empty repo on Github (in our example below, we would call
 it ``blogging_for_humans``) and set up your virtual environment with your
-favorite method.  To request a new repo in the ``edx`` organization, you will
-submit an ITSUPPORT ticket.  Details are in the `How to request a new GitHub
-repo`_ wiki page. This ticket should also request that Travis and Codecov be
-enabled for the new repository.
+favorite method.  If you are an edX employee, request a new repo in the
+``edx`` organization by submitting an ITSUPPORT ticket.  Details are in the
+`How to request a new GitHub repo`_ wiki page. This ticket should also
+request that Travis and Codecov be enabled for the new repository.
 
 .. _How to request a new GitHub repo: https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=70385719
 
@@ -125,8 +125,8 @@ Register on PyPI
 ~~~~~~~~~~~~~~~~~
 
 Once you have at least a prototype working and tests running, it's time to
-register the application on PyPI.  `Open an IT General Request ticket`_ to do
-this, providing:
+register the application on PyPI.  If you are an edX employee,
+`Open an IT General Request ticket`_ to do this, providing:
 
 * The URL of the package's GitHub repository (ask for the ``deploy`` entry in
   ``.travis.yml`` to be updated)
@@ -136,8 +136,12 @@ this, providing:
 This avoids the need to distribute the password for the edx PyPI account too
 widely.
 
+If you are not an edX employee, you can follow the instructions in the Python
+Packaging User Guide on `uploading your project to PyPI`_.
+
 .. _Open an IT General Request ticket: https://openedx.atlassian.net/servicedesk/customer/portal/1/create/7
 .. _PyPI registration URL: https://packaging.python.org/distributing/#register-your-project
+.. _uploading your project to PyPI: https://packaging.python.org/distributing/#uploading-your-project-to-pypi
 
 Releasing on PyPI
 ~~~~~~~~~~~~~~~~~

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -3,4 +3,4 @@
 edx-lint                  # For updating pylintrc
 pip-tools                 # Requirements file management
 tox                       # virtualenv management for tests
-tox-battery==0.2          # Makes tox aware of requirements file changes; restricted by https://github.com/signalpillar/tox-battery/issues/6
+tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,37 +5,41 @@
 #    pip-compile --output-file requirements/dev.txt requirements/base.in requirements/dev.in
 #
 argh==0.26.2              # via watchdog
-arrow==0.10.0             # via jinja2-time
+arrow==0.12.1             # via jinja2-time
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery, pylint-plugin-utils
-binaryornot==0.4.3        # via cookiecutter
-chardet==3.0.2            # via binaryornot
+binaryornot==0.4.4        # via cookiecutter
+certifi==2018.1.18        # via requests
+chardet==3.0.4            # via binaryornot, requests
 click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, cookiecutter, edx-lint, pip-tools
-cookiecutter==1.5.1
-edx-lint==0.5.4
+cookiecutter==1.6.0
+edx-lint==0.5.5
 first==2.0.1              # via pip-tools
 future==0.16.0            # via cookiecutter
-isort==4.2.5              # via pylint
+idna==2.6                 # via requests
+isort==4.2.15             # via pylint
 jinja2-time==0.2.0        # via cookiecutter
-jinja2==2.9.6             # via cookiecutter, jinja2-time
-lazy-object-proxy==1.2.2  # via astroid
+jinja2==2.10              # via cookiecutter, jinja2-time
+lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via pylint
 pathtools==0.1.2          # via watchdog
-pip-tools==1.9.0
-pluggy==0.4.0             # via tox
+pip-tools==1.11.0
+pluggy==0.6.0             # via tox
 poyo==0.4.1               # via cookiecutter
-py==1.4.33                # via tox
+py==1.5.2                 # via tox
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.2.6  # via pylint-celery, pylint-django
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-python-dateutil==2.6.0    # via arrow
+python-dateutil==2.6.1    # via arrow
 pyyaml==3.12              # via watchdog
-six==1.10.0               # via astroid, edx-lint, pip-tools, pylint, python-dateutil
-tox-battery==0.2
-tox==2.7.0
+requests==2.18.4          # via cookiecutter
+six==1.11.0               # via astroid, edx-lint, pip-tools, pylint, python-dateutil, tox
+tox-battery==0.5
+tox==2.9.1
+urllib3==1.22             # via requests
 virtualenv==15.1.0        # via tox
 watchdog==0.8.3
-whichcraft==0.4.0         # via cookiecutter
-wrapt==1.10.10            # via astroid
+whichcraft==0.4.1         # via cookiecutter
+wrapt==1.10.11            # via astroid

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,10 +4,10 @@
 #
 #    pip-compile --output-file requirements/doc.txt requirements/doc.in
 #
-bleach==2.0.0             # via readme-renderer
-docutils==0.13.1          # via readme-renderer
-html5lib==0.999999999     # via bleach
+bleach==2.1.2             # via readme-renderer
+docutils==0.14            # via readme-renderer
+html5lib==1.0.1           # via bleach
 pygments==2.2.0           # via readme-renderer
 readme-renderer==17.2
-six==1.10.0               # via bleach, html5lib, readme-renderer
+six==1.11.0               # via bleach, html5lib, readme-renderer
 webencodings==0.5.1       # via html5lib

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,17 +1,16 @@
 # Requirements for test runs
 
 caniusepython3            # Additional Python 3 compatibility pylint checks
-Django                    # For pylint import checks of the generated output
+Django<2.0                # For pylint import checks of the generated output; version capped until Python 2.7 is dropped
 django-model-utils        # For pylint import checks of the generated output
 edx-lint                  # edX pylint rules and plugins
 edx-sphinx-theme          # For pylint import checks of the generated output
 isort                     # to standardize order of imports
 pycodestyle               # PEP 8 compliance validation
 pydocstyle                # PEP 257 compliance validation
-pytest-catchlog           # Show log output for test failures
 pytest-cookies            # pytest extension for cookiecutter testing
 readme_renderer           # Check README.rst for PyPI compatibility
 sh                        # Used to execute flake8 in tests
-Sphinx<1.5                # Documentation builder; restricted by https://github.com/rtfd/readthedocs.org/issues/2708
+Sphinx                    # Documentation builder
 sphinx_rtd_theme          # For pylint import checks of the generated conf.py
 doc8                      # reStructuredText style checker

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,60 +6,65 @@
 #
 alabaster==0.7.10         # via sphinx
 argparse==1.4.0           # via caniusepython3
-arrow==0.10.0             # via jinja2-time
+arrow==0.12.1             # via jinja2-time
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery, pylint-plugin-utils
-babel==2.4.0              # via sphinx
-backports.functools-lru-cache==1.3  # via caniusepython3
-binaryornot==0.4.3        # via cookiecutter
-bleach==2.0.0             # via readme-renderer
-caniusepython3==5.0.0
-chardet==3.0.2            # via binaryornot, doc8
+attrs==17.4.0             # via pytest
+babel==2.5.3              # via sphinx
+backports.functools-lru-cache==1.4  # via caniusepython3
+binaryornot==0.4.4        # via cookiecutter
+bleach==2.1.2             # via readme-renderer
+caniusepython3==6.0.0
+certifi==2018.1.18        # via requests
+chardet==3.0.4            # via binaryornot, doc8, requests
 click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, cookiecutter, edx-lint
-cookiecutter==1.5.1       # via pytest-cookies
-distlib==0.2.4            # via caniusepython3
-django-model-utils==3.0.0
-django==1.11              # via django-model-utils
+cookiecutter==1.6.0       # via pytest-cookies
+distlib==0.2.6            # via caniusepython3
+django-model-utils==3.1.1
+django==1.11.9
 doc8==0.8.0
-docutils==0.13.1          # via doc8, readme-renderer, restructuredtext-lint, sphinx
-edx-lint==0.5.4
-edx-sphinx-theme==1.0.2
+docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
+edx-lint==0.5.5
+edx-sphinx-theme==1.3.0
 future==0.16.0            # via cookiecutter
 futures==3.1.1            # via caniusepython3
-html5lib==0.999999999     # via bleach
+html5lib==1.0.1           # via bleach
+idna==2.6                 # via requests
 imagesize==0.7.1          # via sphinx
-isort==4.2.5
+isort==4.2.15
 jinja2-time==0.2.0        # via cookiecutter
-jinja2==2.9.6             # via cookiecutter, jinja2-time, sphinx
-lazy-object-proxy==1.2.2  # via astroid
+jinja2==2.10              # via cookiecutter, jinja2-time, sphinx
+lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via pylint
 packaging==16.8           # via caniusepython3
-pbr==3.0.0                # via stevedore
+pbr==3.1.1                # via stevedore
+pluggy==0.6.0             # via pytest
 poyo==0.4.1               # via cookiecutter
-py==1.4.33                # via pytest, pytest-catchlog
+py==1.5.2                 # via pytest
 pycodestyle==2.3.1
-pydocstyle==2.0.0
+pydocstyle==2.1.1
 pygments==2.2.0           # via readme-renderer, sphinx
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.2.6  # via pylint-celery, pylint-django
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.2.0          # via packaging
-pytest-catchlog==1.2.2
-pytest-cookies==0.2.0
-pytest==3.0.7             # via pytest-catchlog, pytest-cookies
-python-dateutil==2.6.0    # via arrow
-pytz==2017.2              # via babel, django
+pytest-cookies==0.3.0
+pytest==3.3.2             # via pytest-cookies
+python-dateutil==2.6.1    # via arrow
+pytz==2017.3              # via babel, django
 readme-renderer==17.2
-requests==2.13.0          # via caniusepython3
-restructuredtext-lint==1.0.1  # via doc8
-sh==1.12.13
-six==1.10.0               # via astroid, bleach, doc8, edx-lint, edx-sphinx-theme, html5lib, packaging, pydocstyle, pylint, python-dateutil, readme-renderer, sphinx, stevedore
+requests==2.18.4          # via caniusepython3, cookiecutter, sphinx
+restructuredtext-lint==1.1.2  # via doc8
+sh==1.12.14
+six==1.11.0               # via astroid, bleach, doc8, edx-lint, edx-sphinx-theme, html5lib, packaging, pydocstyle, pylint, pytest, python-dateutil, readme-renderer, sphinx, stevedore
 snowballstemmer==1.2.1    # via pydocstyle, sphinx
 sphinx-rtd-theme==0.2.4
-sphinx==1.4.9             # via edx-sphinx-theme
-stevedore==1.21.0         # via doc8
+sphinx==1.6.6
+sphinxcontrib-websupport==1.0.1  # via sphinx
+stevedore==1.28.0         # via doc8
+urllib3==1.22             # via requests
 webencodings==0.5.1       # via html5lib
-whichcraft==0.4.0         # via cookiecutter
-wrapt==1.10.10            # via astroid
+whichcraft==0.4.1         # via cookiecutter
+wrapt==1.10.11            # via astroid

--- a/requirements/travis.in
+++ b/requirements/travis.in
@@ -1,4 +1,4 @@
 # Requirements for running tests in Travis
 
 tox                       # Virtualenv management for tests
-tox-battery==0.2          # Makes tox aware of requirements file changes; restricted by https://github.com/signalpillar/tox-battery/issues/6
+tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,8 +4,9 @@
 #
 #    pip-compile --output-file requirements/travis.txt requirements/travis.in
 #
-pluggy==0.4.0             # via tox
-py==1.4.33                # via tox
-tox-battery==0.2
-tox==2.7.0
+pluggy==0.6.0             # via tox
+py==1.5.2                 # via tox
+six==1.11.0               # via tox
+tox-battery==0.5
+tox==2.9.1
 virtualenv==15.1.0        # via tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35}
+envlist = py{27,36}
 skipsdist = true
 
 [pycodestyle]

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -4,18 +4,21 @@ language: python
 
 python:
   - 2.7
-  - 3.5
+  - 3.6
 
 env:
   - TOXENV=django18
-  - TOXENV=django19
-  - TOXENV=django110
+  - TOXENV=django111
+  - TOXENV=django20
 
 matrix:
+  exclude:
+    - python: 2.7
+      env: TOXENV=django20
   include:
-    - python: 3.5
+    - python: 3.6
       env: TOXENV=quality
-    - python: 3.5
+    - python: 3.6
       env: TOXENV=docs
 
 cache:

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -476,8 +476,8 @@ epub_exclude_files = ['search.html']
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.5', None),
-    'django': ('https://docs.djangoproject.com/en/1.10/', 'https://docs.djangoproject.com/en/1.10/_objects/'),
+    'python': ('https://docs.python.org/3.6', None),
+    'django': ('https://docs.djangoproject.com/en/1.11/', 'https://docs.djangoproject.com/en/1.11/_objects/'),
     'model_utils': ('https://django-model-utils.readthedocs.io/en/latest/', None),
 }
 

--- a/{{cookiecutter.repo_name}}/requirements/dev.in
+++ b/{{cookiecutter.repo_name}}/requirements/dev.in
@@ -5,6 +5,6 @@ edx-lint                  # For updating pylintrc
 edx-i18n-tools            # For i18n_tool dummy
 pip-tools                 # Requirements file management
 tox                       # virtualenv management for tests
-tox-battery==0.2          # Makes tox aware of requirements file changes; restricted by https://github.com/signalpillar/tox-battery/issues/6
+tox-battery               # Makes tox aware of requirements file changes
 twine                     # Utility for PyPI package uploads
 wheel                     # For generation of wheels for PyPI

--- a/{{cookiecutter.repo_name}}/requirements/doc.in
+++ b/{{cookiecutter.repo_name}}/requirements/doc.in
@@ -3,4 +3,4 @@
 doc8                      # reStructuredText style checker
 edx_sphinx_theme          # edX theme for Sphinx output
 readme_renderer           # Validates README.rst for usage on PyPI
-Sphinx<1.5                # Documentation builder; restricted by https://github.com/rtfd/readthedocs.org/issues/2708
+Sphinx                    # Documentation builder

--- a/{{cookiecutter.repo_name}}/requirements/test.in
+++ b/{{cookiecutter.repo_name}}/requirements/test.in
@@ -1,6 +1,5 @@
 # Requirements for test runs.
 
 {% if cookiecutter.models != "Comma-separated list of models" %}django-model-utils        # Provides TimeStampedModel abstract base class{% endif %}
-pytest-catchlog           # Show log output for test failures
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support

--- a/{{cookiecutter.repo_name}}/requirements/travis.in
+++ b/{{cookiecutter.repo_name}}/requirements/travis.in
@@ -2,4 +2,4 @@
 
 codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
-tox-battery==0.2          # Makes tox aware of requirements file changes; restricted by https://github.com/signalpillar/tox-battery/issues/6
+tox-battery               # Makes tox aware of requirements file changes

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -49,7 +49,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "Django>=1.8,<1.11"{% if cookiecutter.models != "Comma-separated list of models" %}, "django-model-utils>=2.0"{% endif %}
+        "Django>=1.8,<2.1"{% if cookiecutter.models != "Comma-separated list of models" %}, "django-model-utils>=2.0"{% endif %}
     ],
 {%- if cookiecutter.open_source_license in license_classifiers %}
     license="{{ cookiecutter.open_source_license }}",
@@ -60,8 +60,8 @@ setup(
         'Development Status :: 3 - Alpha',
         'Framework :: Django',
         'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
-        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',{% if cookiecutter.open_source_license == "AGPL 3.0" %}
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',{% elif cookiecutter.open_source_license == "Apache Software License 2.0" %}
         'License :: OSI Approved :: Apache Software License',{% else %}
@@ -70,6 +70,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py35}-django{18,19,110,111}
+envlist = {py27,py36}-django{18,111},py36-django20
 
 [doc8]
 max-line-length = 120
@@ -24,9 +24,8 @@ norecursedirs = .* docs requirements
 [testenv]
 deps =
     django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
-    django111: Django>=1.11,<1.12
+    django111: Django>=1.11,<2.0
+    django20: Django>=2.0,<2.1
     -r{toxinidir}/requirements/test.txt
 commands =
     py.test {posargs}


### PR DESCRIPTION
Assorted updates to keep the cookiecutter up to date:

* Switch from Python 3.5 to 3.6 (does anybody think we need to keep 3.5 testing for compatibility with any IDAs that may be on it?)
* Test against all currently supported Django versions
* Remove version caps on `Sphinx` and `tox-battery` since the relevant bugs have been fixed
* `pytest-catchlog` has been rolled into core `pytest`, so removed that dependency
* Upgraded all other dependencies
* Made some doc updates to be more clear for non-edX employees also