### PR TITLE
Ignore .pytest_cache

### DIFF
--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -1,5 +1,6 @@
 *.py[cod]
 __pycache__
+.pytest_cache
 
 # C extensions
 *.so


### PR DESCRIPTION
I committed `.pytest_cache` once or twice to my branch, which is annoying. So I think it's worth ignoring it by default.