### PR TITLE
Add Python 3.6 requirement.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Enter the project and take a look around::
     $ ls
 
 Generate a virtualenv and generate requirements files with dependencies
-pinned to current versions (make sure you're using pip 7 or later)::
+pinned to current versions (make sure you're using pip 9.0.2+ and Python 3.6)::
 
     $ mkvirtualenv Blogging-for-humans
     $ make upgrade


### PR DESCRIPTION
For now, you must use Python 3.6 to create your virtualenv.  Currently,
pytest will fail with Python 3.7.

On Mac with Homebrew, installing Python 3 will give 3.7, so you need
to follow this doc:
https://stackoverflow.com/questions/51125013/how-can-i-install-a-previous-version-of-python-3-in-macos-using-homebrew