### PR TITLE
Add requirements/base.in to MANIFEST.in

### DIFF
--- a/{{cookiecutter.repo_name}}/MANIFEST.in
+++ b/{{cookiecutter.repo_name}}/MANIFEST.in
@@ -3,4 +3,5 @@ include CHANGELOG.rst
 include CONTRIBUTING.rst
 include LICENSE.txt
 include README.rst
+include requirements/base.in
 recursive-include {{cookiecutter.app_name}} *.html *.png *.gif *js *.css *jpg *jpeg *svg *py


### PR DESCRIPTION
Include `requirements/base.in` in the distributed package so `setup.py` can find the core dependencies listing.