### PR TITLE
Fix pydocstyle config for recent versions

### DIFF
--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -187,8 +187,7 @@ def check_quality(result):
                 sh.pylint(name, rcfile=pylintrc)
                 sh.pylint(name, py3k=True)
                 sh.pycodestyle(name)
-                if filename != 'setup.py':
-                    sh.pydocstyle(name)
+                sh.pydocstyle(name)
                 sh.isort(name, check_only=True, diff=True)
             except sh.ErrorReturnCode as exc:
                 pytest.fail(str(exc))

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skipsdist = true
 max-line-length = 120
 
 [pydocstyle]
-ignore = D200,D203,D212
+ignore = D200,D203,D212,D215,D404,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414
 
 [pytest]
 testpaths = tests/

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # pylint: disable=C0111,W6005,W6100
+"""
+Package metadata for {{ cookiecutter.app_name }}.
+"""
 from __future__ import absolute_import, print_function
 
 import os
@@ -28,7 +31,9 @@ def get_version(*file_paths):
 def load_requirements(*requirements_paths):
     """
     Load all requirements from the specified requirements files.
-    Returns a list of requirement strings.
+
+    Returns:
+        list: Requirements file relative path strings
     """
     requirements = set()
     for path in requirements_paths:
@@ -41,8 +46,10 @@ def load_requirements(*requirements_paths):
 
 def is_requirement(line):
     """
-    Return True if the requirement line is a package requirement;
-    that is, it is not blank, a comment, a URL, or an included file.
+    Return True if the requirement line is a package requirement.
+
+    Returns:
+        bool: True if the line is not blank, a comment, a URL, or an included file
     """
     return not (
         line == '' or

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -13,7 +13,19 @@ max-line-length = 120
 ; D200 = One-line docstring should fit on one line with quotes
 ; D203 = 1 blank line required before class docstring
 ; D212 = Multi-line docstring summary should start at the first line
-ignore = D101,D200,D203,D212
+; D215 = Section underline is over-indented (numpy style)
+; D404 = First word of the docstring should not be This (numpy style)
+; D405 = Section name should be properly capitalized (numpy style)
+; D406 = Section name should end with a newline (numpy style)
+; D407 = Missing dashed underline after section (numpy style)
+; D408 = Section underline should be in the line following the section’s name (numpy style)
+; D409 = Section underline should match the length of its name (numpy style)
+; D410 = Missing blank line after section (numpy style)
+; D411 = Missing blank line before section (numpy style)
+; D412 = No blank lines allowed between a section header and its content (numpy style)
+; D413 = Missing blank line after last section (numpy style)
+; D414 = Section has no content (numpy style)
+ignore = D101,D200,D203,D212,D215,D404,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414
 match-dir = (?!migrations)
 
 [pytest]


### PR DESCRIPTION
`pydocstyle` recently added some checks (enabled by default) for numpy-style docstrings, which conflict with the Google style we've chosen to use.  Turn these off, and make sure that setup.py validates successfully.