### PR TITLE
Add PII annotations checking

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,22 @@ Create a GitHub repo and push it there::
 
 Now take a look at your repo. Awesome, right?
 
-It's time to write the code!!!
+
+Address TODOs
+~~~~~~~~~~~~~~~~~
+
+Look around in the new repo for sections marked `TODO`.  Here are a few known
+places where they may appear:
+
+* `openedx.yaml`: Various OEP states need to be updated.  See `OEP-2\: Repository Metadata`_ for more information.
+* `{{cookiecutter.app_name}}/models.py`: If you specified any models to generate, the various docstrings need to be filled in, and PII annotations need to be added.  See `OEP-30\: PII Markup and Auditing`_ for more information on PII annotations.
+* `tests/test_models.py`: Fill in docstrings here too.
+
+.. _OEP-2\: Repository Metadata: https://open-edx-proposals.readthedocs.io/en/latest/oep-0002-bp-repo-metadata.html
+.. _OEP-30\: PII Markup and Auditing: https://open-edx-proposals.readthedocs.io/en/latest/oep-0030-arch-pii-markup-and-auditing.html
+
+Finally, it's time to write the code!!!
+
 
 Running Tests
 ~~~~~~~~~~~~~~~~~

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,6 +9,6 @@
   "models": "Comma-separated list of models",
   "config_class_name": "{{ cookiecutter.app_name|replace('_', ' ')|title|replace(' ', '') }}Config",
   "version": "0.1.0",
-  "owner": "edx/platform-team",
+  "owner": "edx/devops",
   "open_source_license": ["AGPL 3.0", "Apache Software License 2.0", "Not open source"]
 }

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,7 +1,7 @@
 # openedx.yaml
 
 ---
-owner: edx/platform-team
+owner: edx/core
 nick: cookiecutter-django-app
 tags:
     - tools
@@ -13,3 +13,5 @@ oeps:
     oep-5:
         state: False
         reason: Doesn't require any services to be started
+    oep-30:
+        applicable: False

--- a/{{cookiecutter.repo_name}}/.annotation_safe_list.yml
+++ b/{{cookiecutter.repo_name}}/.annotation_safe_list.yml
@@ -1,0 +1,19 @@
+# This is a Code Annotations automatically-generated Django model safelist file.
+# These models must be annotated as follows in order to be counted in the coverage report.
+# See https://code-annotations.readthedocs.io/en/latest/safelist.html for more information.
+#
+# fake_app_1.FakeModelName:
+#    ".. no_pii::": "This model has no PII"
+# fake_app_2.FakeModel2:
+#    ".. choice_annotation::": foo, bar, baz
+
+auth.Group:
+  ".. no_pii:": "This model has no PII"
+auth.Permission:
+  ".. no_pii:": "This model has no PII"
+auth.User:
+  ".. pii:": "Contains username, password, and email address, must be retired in the consumer of this app"
+  ".. pii_types:" : username, email_address, password
+  ".. pii_retirement:" : consumer_api
+contenttypes.ContentType:
+  ".. no_pii:": "This model has no PII"

--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -32,6 +32,9 @@ pip-log.txt
 coverage.xml
 htmlcov/
 
+# PII annotation reports
+pii_report
+
 # Translations
 *.mo
 

--- a/{{cookiecutter.repo_name}}/.pii_annotations.yml
+++ b/{{cookiecutter.repo_name}}/.pii_annotations.yml
@@ -1,0 +1,35 @@
+source_path: ./
+report_path: pii_report
+safelist_path: .annotation_safe_list.yml
+coverage_target: 100.0
+annotations:
+    ".. no_pii:":
+    "pii_group":
+        - ".. pii:":
+        - ".. pii_types:":
+            choices:
+              - id # Unique identifier for the user which is shared across systems
+              - name # Used for any part of the user’s name
+              - username
+              - password
+              - location # Used for any part of any type address or country stored
+              - phone_number # Used for phone or fax numbers
+              - email_address
+              - birth_date # Used for any part of a stored birth date
+              - ip # IP address
+              - external_service # Used for external service ids or links such as social media links or usernames, website links, etc.
+              - biography # Any type of free-form biography field
+              - gender
+              - sex
+              - image
+              - video
+              - other
+        - ".. pii_retirement:":
+            choices:
+              - retained     # Intentionally kept for legal reasons
+              - local_api    # An API exists in this repository for retiring this information
+              - consumer_api # The data's consumer must implement an API for retiring this information
+              - third_party  # A third party API exists to retire this data
+extensions:
+    python:
+        - py

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -20,6 +20,8 @@ matrix:
       env: TOXENV=quality
     - python: 3.6
       env: TOXENV=docs
+    - python: 3.6
+      env: TOXENV=pii_check
 
 cache:
   - pip

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -1,6 +1,6 @@
 .PHONY: clean compile_translations coverage diff_cover docs dummy_translations \
-	extract_translations fake_translations help pull_translations push_translations \
-	quality requirements selfcheck test test-all upgrade validate
+        extract_translations fake_translations help pii_check pull_translations push_translations \
+        quality requirements selfcheck test test-all upgrade validate
 
 .DEFAULT_GOAL := help
 
@@ -56,6 +56,9 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 quality: ## check coding style with pycodestyle and pylint
 	tox -e quality
 
+pii_check: ## check for PII annotations on all Django models
+	tox -e pii_check
+
 requirements: ## install development environment requirements
 	pip install -qr requirements/pip-tools.txt
 	pip-sync requirements/dev.txt requirements/private.*
@@ -66,11 +69,10 @@ test: clean ## run tests in the current virtualenv
 diff_cover: test ## find diff lines that need test coverage
 	diff-cover coverage.xml
 
-test-all: ## run tests on every supported Python/Django combination
-	tox -e quality
+test-all: quality pii_check ## run tests on every supported Python/Django combination
 	tox
 
-validate: quality test ## run tests and quality checks
+validate: quality pii_check test ## run tests and quality checks
 
 selfcheck: ## check that the Makefile is well-formed
 	@echo "The Makefile is well-formed."

--- a/{{cookiecutter.repo_name}}/openedx.yaml
+++ b/{{cookiecutter.repo_name}}/openedx.yaml
@@ -13,3 +13,5 @@ oeps:
     oep-5:
         state: False
         reason: TODO - Implement for this application if appropriate
+    oep-30:
+        state: True

--- a/{{cookiecutter.repo_name}}/requirements/pip-tools.txt
+++ b/{{cookiecutter.repo_name}}/requirements/pip-tools.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-click==6.7                # via pip-tools
-first==2.0.1              # via pip-tools
-pip-tools==2.0.2
-six==1.11.0               # via pip-tools
+click==7.0                # via pip-tools
+pip-tools==3.3.2
+six==1.12.0               # via pip-tools

--- a/{{cookiecutter.repo_name}}/requirements/test.in
+++ b/{{cookiecutter.repo_name}}/requirements/test.in
@@ -4,3 +4,4 @@
 
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
+code-annotations          # provides commands used by the pii_check make target.

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -75,3 +75,11 @@ commands =
     pydocstyle {{ cookiecutter.app_name }} tests manage.py setup.py
     isort --check-only --diff --recursive tests test_utils {{ cookiecutter.app_name }} manage.py setup.py test_settings.py
     make selfcheck
+
+[testenv:pii_check]
+setenv =
+    DJANGO_SETTINGS_MODULE = test_settings
+deps =
+    -r{toxinidir}/requirements/test.txt
+commands =
+    code_annotations django_find_annotations --config_file .pii_annotations.yml --lint --report --coverage

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/models.py
@@ -14,6 +14,10 @@ from model_utils.models import TimeStampedModel
 class {{ model.strip() }}(TimeStampedModel):
     """
     TODO: replace with a brief description of the model.
+
+    TODO: Add either a negative or a positive PII annotation to the end of this docstring.  For more
+    information, see OEP-30:
+    https://open-edx-proposals.readthedocs.io/en/latest/oep-0030-arch-pii-markup-and-auditing.html
     """
 
     # TODO: add field definitions


### PR DESCRIPTION
In summary:

* Add code-annotations package, config file, and add it to CI.
* Add known remote annotations.
* Add PII annotation notices in the docstrings of local auto-generated models.
* Replace instances of `str()` with `six.text_type()`.