### PR TITLE
change django min version to 1.11

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements/base.in
+++ b/{{cookiecutter.repo_name}}/requirements/base.in
@@ -1,4 +1,4 @@
 # Core requirements for using this application
 
-Django>=1.8,<2.0          # Web application framework
+Django>=1.11,<2.0          # Web application framework
 {% if cookiecutter.models != "Comma-separated list of models" %}django-model-utils        # Provides TimeStampedModel abstract base class{% endif %}

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -92,7 +92,6 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',{% if cookiecutter.open_source_license == "AGPL 3.0" %}

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -35,7 +35,6 @@ norecursedirs = .* docs requirements
 
 [testenv]
 deps =
-    django18: Django>=1.8,<1.9
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     -r{toxinidir}/requirements/test.txt


### PR DESCRIPTION
We don't support any versions lower than Django 1.11. This removes any mention of 1.8.